### PR TITLE
Fix child-parent pair test

### DIFF
--- a/BuildTreeQuestConsole/TestDataChecker.cs
+++ b/BuildTreeQuestConsole/TestDataChecker.cs
@@ -41,7 +41,7 @@ namespace BuildTreeQuestConsole
 
         private static bool IsCorrectChildParentPair(string childChapter, string parentChapter)
         {
-            return childChapter.StartsWith(parentChapter + ".");
+            return childChapter.StartsWith(parentChapter + ".") && childChapter.LastIndexOf('.') == parentChapter.Length;
         }
     }
 }


### PR DESCRIPTION
Add a check to test against case when "1.1.1.1" starts with "1.1." but should fail